### PR TITLE
fix: resolve frpc binary naming conflict on arm64/aarch64

### DIFF
--- a/gradio_tunneling/main.py
+++ b/gradio_tunneling/main.py
@@ -17,6 +17,8 @@ CURRENT_TUNNELS: List["Tunnel"] = []
 machine = platform.machine()
 if machine == "x86_64":
     machine = "amd64"
+elif machine == "aarch64":
+    machine = "arm64"
 
 BINARY_REMOTE_NAME = f"frpc_{platform.system().lower()}_{machine.lower()}"
 EXTENSION = ".exe" if os.name == "nt" else ""


### PR DESCRIPTION
### Description
This PR resolves an issue where the `frpc` binary name is incorrectly generated on aarch64 machine.

### References
Consistent with Gradio's official repo: [gradio/tunneling.py#L20](https://github.com/gradio-app/gradio/blob/ebbd24231dbc006c21fbbf1df00918be16883b86/gradio/tunneling.py#L20)